### PR TITLE
Update image link to raw image link to solve display issue in pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ installed on your system. Both physical and simulated devices are supported.
 You can use **NI MAX** or **NI Hardware Configuration Utility** to verify and configure your devices.
 
 Finding and configuring device name in **NI MAX**:
-![NI Max Device Name](https://github.com/ni/nisync-python/blob/a3b91643a1e110fbc3a6bc9c5dc517f74c13ee80/docs/img/max_device_name.png)
+![NI Max Device Name](https://raw.githubusercontent.com/ni/nisync-python/a3b91643a1e110fbc3a6bc9c5dc517f74c13ee80/docs/img/max_device_name.png)
 
 Finding and configuring device name in **NI Hardware Configuration Utility**:
-![NI HWCU Device Name](https://github.com/ni/nisync-python/blob/a3b91643a1e110fbc3a6bc9c5dc517f74c13ee80/docs/img/hwcu_device_name.png)
+![NI HWCU Device Name](https://raw.githubusercontent.com/ni/nisync-python/a3b91643a1e110fbc3a6bc9c5dc517f74c13ee80/docs/img/hwcu_device_name.png)
 
 
 # Usage


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisync-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?
Update the image link to raw image link

### Why should this Pull Request be merged?
The previous image permalink cannot be displayed in test pypi ([https://test.pypi.org/project/nisync/0.0.1/](https://test.pypi.org/project/nisync/0.0.1/))
![Screenshot 2024-08-27 181153](https://github.com/user-attachments/assets/ec088180-c1a4-4db0-ae9f-dcb55d16595f)
The images should be displayed properly.

### What testing has been done?
https://test.pypi.org/project/nisync/0.0.3/
![image](https://github.com/user-attachments/assets/c7ee89e4-a112-4222-b7c7-cd5aa861d6a1)
