### PR TITLE
Provide session handle for nisync session

### DIFF
--- a/nisync/session.py
+++ b/nisync/session.py
@@ -864,6 +864,9 @@ class Session(_SessionBase):
     def resource_name(self):
         return self._resource_name
 
+    @property
+    def handle(self):
+        return _visatype.ViSession(self._vi)
 
 class TimeReference(object):
     def __init__(self, session):


### PR DESCRIPTION
- [x ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisync-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?
NI-Digital needs session handle from nisync for their development.
Add function at return (read only) handle of the session

### Why should this Pull Request be merged?

Allow the user read the session handle

### What testing has been done?

