### PR TITLE
GitHub: Upgrade GitHub actions that depend on deprecated Node.js versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           # The codegen scripts require Python 3.8 or later.
           python-version: "3.8"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
           # The codegen scripts require Python 3.8 or later.
           python-version: "3.8"
       - name: Set up Poetry
-        uses: Gr1N/setup-poetry@v8
+        uses: Gr1N/setup-poetry@v9
         with:
           poetry-version: "1.8.3"
       - name: Check Poetry version

--- a/.github/workflows/report_test_results.yml
+++ b/.github/workflows/report_test_results.yml
@@ -18,10 +18,11 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v4
       - name: Download test results
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: test_results
           path: test_results
+          pattern: test_results_*
+          merge-multiple: true
       - name: List downloaded files
         run: ls -lR
       - name: Publish test results

--- a/.github/workflows/run_acceptance_tests.yml
+++ b/.github/workflows/run_acceptance_tests.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install dependencies
         run: poetry install
       - name: Run acceptance tests for PXIe-6674T

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Run unit tests
         run: poetry run pytest -v --junitxml=test_results/unit-${{ matrix.os }}-py${{ matrix.python-version }}.xml
       - name: Upload test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: test_results
+          name: test_results_unit_${{ matrix.os }}_py${{ matrix.python-version }}
           path: test_results/*.xml
         if: always()

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up Poetry
-        uses: Gr1N/setup-poetry@v8
+        uses: Gr1N/setup-poetry@v9
         with:
           poetry-version: "1.8.3"
       - name: Check Poetry version

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up Poetry


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisync-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?
1. Upgrade setup-python to v5
2. Upgrade upload/download-artifact to v4
3. Upgrade Gr1N/setup-poetry v9
4. Upgrade actions/checkout to v4
5. Rename test_results files and merge it 

### Why should this Pull Request be merged?
To resolve:  https://github.com/ni/nisync-python/actions/runs/10628769806
The following actions use a deprecated Node.js version and will be forced to run on node20: actions/setup-python@v4, Gr1N/setup-poetry@v8. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

### What testing has been done?
PR build
