### PR TITLE
Add function to return session handle from nisync

### DIFF
--- a/nisync/session.py
+++ b/nisync/session.py
@@ -866,7 +866,7 @@ class Session(_SessionBase):
 
     @property
     def session_handle(self):
-        return _visatype.ViSession(self._vi)
+        return self._vi
 
 
 class TimeReference(object):

--- a/nisync/session.py
+++ b/nisync/session.py
@@ -864,6 +864,10 @@ class Session(_SessionBase):
     def resource_name(self):
         return self._resource_name
 
+    @property
+    def session_handle(self):
+        return _visatype.ViSession(self._vi)
+
 
 class TimeReference(object):
     def __init__(self, session):

--- a/templates/nisync/session.py.mako
+++ b/templates/nisync/session.py.mako
@@ -649,6 +649,11 @@ class Session(_SessionBase):
     @property
     def resource_name(self):
         return self._resource_name
+    
+    @property
+    def session_handle(self):
+        return _visatype.ViSession(self._vi)
+
 <%
     class_hierarchy = [
         ('TimeReference',           'object'),

--- a/templates/nisync/session.py.mako
+++ b/templates/nisync/session.py.mako
@@ -652,7 +652,7 @@ class Session(_SessionBase):
     
     @property
     def session_handle(self):
-        return _visatype.ViSession(self._vi)
+        return self._vi
 
 <%
     class_hierarchy = [

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -194,6 +194,7 @@ def test___session___disconnect_clock_terminals___succeeds(lib_mock):
     ]
     assert lib_mock.mock_calls == expected_calls
 
+
 def test___session___compare_session_handle___succeeds(lib_mock):
     session = nisync.Session(RESOURCE_NAME)
     assert session.session_handle == SESSION_HANDLE.value

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -193,3 +193,14 @@ def test___session___disconnect_clock_terminals___succeeds(lib_mock):
         mock.call.niSync_close(SESSION_HANDLE),
     ]
     assert lib_mock.mock_calls == expected_calls
+
+def test___session___compare_session_handle___succeeds(lib_mock):
+    session = nisync.Session(RESOURCE_NAME)
+    assert session.session_handle == SESSION_HANDLE.value
+    session.close()
+
+    expected_calls = [
+        mock.call.niSync_init(RESOURCE_NAME.encode(), VI_FALSE, VI_FALSE, mock.ANY),
+        mock.call.niSync_close(SESSION_HANDLE),
+    ]
+    assert lib_mock.mock_calls == expected_calls


### PR DESCRIPTION
Signed-off-by: wchung <wai.kin.chung@ni.com>

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisync-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add a function that return read-only session handle.

### Why should this Pull Request be merged?

Existing function that returning session object cannot fulfill NI-Digital use case.

### What testing has been done?
PR Build 
[manual pytest]
1. Added and ran a new regression test for session_handle function.
2. Ran command "poetry run ni-python-styleguide lint" and "poetry run ni-python-styleguide fix" to correct the code format as one of the requirement in CONTRIBUTING.md.
![image](https://github.com/user-attachments/assets/2f80b625-1a85-4654-ab52-324a27218467)

