### PR TITLE
github: Add issue templates and GitHub->AzDO issue syncing

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,49 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: 'bug,triage'
+---
+
+<!---
+Thanks for filing an issue! Before you submit, please read the following:
+
+Search open/closed issues before submitting. Someone may have reported the same issue before.
+-->
+
+# Bug Report
+
+<!--- Provide a general summary of the issue here -->
+
+## Repro or Code Sample
+
+<!-- Please provide steps to reproduce the issue and/or a code repository, gist, code snippet or sample files -->
+
+## Expected Behavior
+
+<!--- Tell us what should happen -->
+
+## Current Behavior
+
+<!--- Tell us what happens instead of the expected behavior -->
+<!--- If you are seeing an error, please include the full error message and stack trace -->
+<!--- If applicable, provide screenshots -->
+
+## Possible Solution
+
+<!--- Not obligatory, but suggest a fix/reason for the bug -->
+<!--- Please let us know if you'd be willing to contribute the fix; we'd be happy to work with you -->
+
+## Context
+
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+## Your Environment
+
+<!--- Include as many relevant details as possible about the environment you experienced the bug in -->
+
+* Operating system and version: [e.g. Windows 11 24H2, Ubuntu Linux 24.04]
+* NI-Sync version: [e.g. 2024 Q4]
+* `nisync-python` version: [e.g. 1.0.1]
+* Python version [e.g. 3.9]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: 'enhancement,triage'
+---
+
+<!---
+Thanks for filing an issue! Before you submit, please read the following:
+
+Search open/closed issues before submitting. Someone may have requested the same feature before.
+-->
+
+## Problem to Solve
+
+<!--- Provide a clear and concise description of why this feature is wanted or what problem it solves. -->
+
+## Proposed Solution
+
+<!--- Provide a clear and concise description of the feature you're proposing. -->
+
+<!--- The implementing team may build a list of tasks/sub-issues here:
+## Tasks
+- [ ] This is a subtask of the feature. (It can be converted to an issue.)
+-->

--- a/.github/ISSUE_TEMPLATE/tech_debt.md
+++ b/.github/ISSUE_TEMPLATE/tech_debt.md
@@ -1,0 +1,7 @@
+---
+name: Tech debt
+about: (DEV TEAM ONLY) Non-user-visible improvement to code or development process
+title: ''
+labels: 'tech debt,triage'
+---
+## Tech Debt

--- a/.github/ISSUE_TEMPLATE/user_story.md
+++ b/.github/ISSUE_TEMPLATE/user_story.md
@@ -1,0 +1,10 @@
+---
+name: User story
+about: (DEV TEAM ONLY) A small chunk of work to be done
+title: '(Fully descriptive title)'
+labels: 'user story,triage'
+---
+
+<!-- Ensure the title can be understood without the parent item's context, e.g. "nimble-button Angular wrapper" rather than just "Angular wrapper" -->
+
+## User Story

--- a/.github/workflows/sync_github_issues_to_azdo.yml
+++ b/.github/workflows/sync_github_issues_to_azdo.yml
@@ -1,0 +1,38 @@
+name: Sync issue to Azure DevOps work item
+
+on:
+  issues:
+    # Omit "labeled" and "unlabeled" to work around https://github.com/danhellem/github-actions-issue-to-work-item/issues/70
+    types:
+      [opened, edited, deleted, closed, reopened, assigned]
+  issue_comment:
+    types: [created, edited, deleted]
+
+jobs:
+  alert:
+    if: ${{ !github.event.issue.pull_request && github.event.issue.title != 'Dependency Dashboard' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Choose work item type
+        id: choose_work_item_type
+        run: |
+          if [ "${{ contains(github.event.issue.labels.*.name, 'enhancement') || contains(github.event.issue.labels.*.name, 'user story') }}" == "true" ]; then
+            echo "work_item_type=User Story" >> $GITHUB_OUTPUT
+          elif [ "${{ contains(github.event.issue.labels.*.name, 'tech debt') }}" == "true" ]; then
+            echo "work_item_type=Technical Debt" >> $GITHUB_OUTPUT
+          else
+            echo "work_item_type=Bug" >> $GITHUB_OUTPUT
+          fi
+      - uses: danhellem/github-actions-issue-to-work-item@v2.4
+        env:
+          ado_token: "${{ secrets.AZDO_WORK_ITEM_TOKEN }}"
+          github_token: "${{ secrets.GH_REPO_TOKEN }}"
+          ado_organization: "ni"
+          ado_project: "DevCentral"
+          ado_area_path: "DevCentral\\Product RnD\\Platform HW and SW\\Core SW and Drivers\\Platform HW and Drivers\\Drivers\\Mars"
+          ado_wit: "${{ steps.choose_work_item_type.outputs.work_item_type }}"
+          ado_new_state: "New"
+          ado_active_state: "Active"
+          ado_close_state: "Closed"
+          ado_bypassrules: true
+          log_level: 100


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisync-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?
Copy most of the content from [DAQmx PR](https://github.com/ni/nidaqmx-python/pull/686)
- Add GitHub issue template based on https://github.com/ni/ni-apis/tree/main/.github/ISSUE_TEMPLATE
- Add a GitHub Actions workflow that syncs GitHub issues to Azure DevOps using [https://github.com/danhellem/github-actions-issue-to-work-item](https://github.com/danhellem/github-actions-issue-to-work-item)
The workflow is based on [ https://github.com/ni/measurement-plugin-python/blob/main/.github/workflows/sync_github_issues_to_azdo.yml](https://github.com/ni/measurement-plugin-python/blob/main/.github/workflows/sync_github_issues_to_azdo.yml)
- By referring daqmx, I created two new labels(tech debt and user story) before this PR is merged.
- What is difference from [DAQmx PR](https://github.com/ni/nidaqmx-python/pull/686)

1.  'ado_area_path' : Area path of the issue in Azure DevOps
2.  package name in bug_report.md

### Why should this Pull Request be merged?
Provide more guidance for which information to include in bug reports.
Automatically sync bug reports to Azure DevOps so they get more visibility.

### What testing has been done?
None
