### PR TITLE
Remove support Python3.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,8 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          # The codegen scripts require Python 3.8 or later.
-          python-version: "3.8"
+          # The codegen scripts require Python 3.9 or later.
+          python-version: "3.9"
       - name: Set up Poetry
         uses: Gr1N/setup-poetry@v9
         with:

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
       # Fail-fast skews the pass/fail ratio and seems to make pytest produce
       # incomplete JUnit XML results.
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ system.
 
 ## Python Version Support
 
-**nisync** supports CPython 3.8+ and PyPy3.
+**nisync** supports CPython 3.9+ and PyPy3.
 
 # Installation
  

--- a/poetry.lock
+++ b/poetry.lock
@@ -736,5 +736,5 @@ files = [
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.8.1"
-content-hash = "682f33f45a7e2aefa60e0efdd8641af2225b7f032160f2fa47ff9d034ce09783"
+python-versions = "^3.9"
+content-hash = "a644b6a7cdb97321309796802b3e7457ccd0bd5b526055cec417480400847d06"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -27,7 +26,7 @@ classifiers = [
 include = ["nisync/*"]
 
 [tool.poetry.dependencies]
-python = "^3.8.1"
+python = "^3.9"
 hightime = "*"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisync-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?
Remove support Python 3.8

### Why should this Pull Request be merged?

Python 3.8 is EOL ([Link](https://devguide.python.org/versions/#versions))

### What testing has been done?
Passed pytest and ni-python-styleguide
TODO: Detail what testing has been done to ensure this submission meets requirements.
