### PR TITLE
github: Use shared Renovate config 

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,10 +1,6 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "branchPrefix": "users/renovate/",
-  "extends": [
-    "config:recommended", 
-    ":maintainLockFilesWeekly",
-    ":automergePatch",
-    "schedule:automergeDaily"
-  ]
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "local>ni/python-renovate-config:recommended"
+    ]
 }


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisync-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?
Use ni recommended renovate setting from ni/python-renovate-config

### Why should this Pull Request be merged?
To align package upgrade configuration provided

### What testing has been done?
Run format test as mentioned in CONTRIBUTING.md
