### PR TITLE
github: Use ni/python-action for python and poetry setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,14 +12,9 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v5
       - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          # The codegen scripts require Python 3.9 or later.
-          python-version: "3.9"
+        uses: ni/python-actions/setup-python@v0.1.0
       - name: Set up Poetry
-        uses: Gr1N/setup-poetry@v9
-        with:
-          poetry-version: "1.8.3"
+        uses: ni/python-actions/setup-poetry@v0.1.0
       - name: Check Poetry version
         run: poetry --version
       - name: Install dependencies

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -19,13 +19,11 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v5
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: ni/python-actions/setup-python@v0.1.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up Poetry
-        uses: Gr1N/setup-poetry@v9
-        with:
-          poetry-version: "1.8.3"
+        uses: ni/python-actions/setup-poetry@v0.1.0
       - name: Check Poetry version
         run: poetry --version
       - name: Install main package dependencies


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisync-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?
Use https://github.com/ni/python-actions/ to set up Python and Poetry.

### Why should this Pull Request be merged?
Single-source default Python and Poetry versions which align to others NI repo

### What testing has been done?
PR Build
