### PR TITLE
Add "Instrument Drivers" classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Instrument Drivers",
     "Topic :: System :: Hardware",
 ]
 include = ["nisync/*"]


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisync-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update the nisync package to use the new `Topic :: Scientific/Engineering :: Instrument Drivers` classifier added in https://github.com/pypa/trove-classifiers/pull/221

### Why should this Pull Request be merged?

Aid package discoverability on PyPI.

### What testing has been done?

N/A