### PR TITLE
Fix incorrect driver name in DriverNotInstalledError

### DIFF
--- a/nisync/errors.py
+++ b/nisync/errors.py
@@ -50,7 +50,7 @@ class UnsupportedConfigurationError(Error):
 class DriverNotInstalledError(Error):
     def __init__(self):
         super(DriverNotInstalledError, self).__init__(
-            "The NI-DMM runtime could not be loaded. Make sure it is installed and its bitness matches that of your Python interpreter. Please visit http://www.ni.com/downloads/drivers/ to download and install it."
+            "The NI-Sync runtime could not be loaded. Make sure it is installed and its bitness matches that of your Python interpreter. Please visit http://www.ni.com/downloads/drivers/ to download and install it."
         )
 
 


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisync-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?
To correct the wrong driver's name in DriverNotInstalledError.
Reported in https://github.com/ni/nisync-python/issues/68

### Why should this Pull Request be merged?
To provide accurate error message

### What testing has been done?
1. Run pytest in poetry
