### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # These owners will be the default owners for everything in the repo.
-* @tkrebes @tsengguanyung @CHrislian-NI @ni/mars-platform-team
+* @tkrebes @tsengguanyung @CHrislian-NI @ni/teams/mars-platform-team


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisync-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fix Team CODEOWNER

### Why should this Pull Request be merged?

The original Team CODEOWNER path is broken, this fixes the path to pull correct users into PR

### What testing has been done?

N/A
